### PR TITLE
Use just one client, the latest one

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,23 +27,9 @@ $ gem install exponent-server-sdk
 
 ## Usage
 
-### Legacy
+### Client
 
-There is a legacy client that uses version 1 of the api.  It's simpler but has limitations like only allowing you to publish messages to a single user per call.
-
-```ruby
-exponent = Exponent::Push::LegacyClient.new
-
-exponent.publish(
-  exponentPushToken: token,
-  message: message,
-  data: {a: 'b'}, # Any arbitrary data to include with the notification
-)
-```
-
-### Current
-
-The new client is the preferred way.  This hits the latest version of the api.
+The push client is the preferred way.  This hits the latest version of the api.
 
 ```ruby
 exponent = Exponent::Push::Client.new

--- a/exponent-server-sdk.gemspec
+++ b/exponent-server-sdk.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "httparty"
+  spec.add_dependency "typhoeus"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
Removing `LegacyClient` in favor of having one client which handles
the latest response formats. Refactoring implementation and replacing
`httparty` with `typhoeus`. Updating README and adding tests.