### PR TITLE
remove encoding

### DIFF
--- a/lib/exponent-server-sdk.rb
+++ b/lib/exponent-server-sdk.rb
@@ -69,8 +69,7 @@ module Exponent
       def headers
         {
           'Content-Type'    => 'application/json',
-          'Accept'          => 'application/json',
-          'Accept-Encoding' => 'gzip, deflate'
+          'Accept'          => 'application/json'
         }
       end
 

--- a/test/exponent-server-sdk-test.rb
+++ b/test/exponent-server-sdk-test.rb
@@ -109,8 +109,7 @@ class ExponentServerSdkTest < Minitest::Test
         body: messages.to_json,
         headers: {
           'Content-Type' => 'application/json',
-          'Accept' => 'application/json',
-          'Accept-Encoding' => 'gzip, deflate'
+          'Accept' => 'application/json'
         }
       }
     ]


### PR DESCRIPTION
parse_json cant parse encoded response.body.

Other alternative would be to decompress gzipped response body.
I opted to remove gzip deflate. 
